### PR TITLE
refactor: Change placeholder nuxt module configKey from 'unpluginStarter' to 'jsxVapor'

### DIFF
--- a/packages/vue-jsx-vapor/src/nuxt.ts
+++ b/packages/vue-jsx-vapor/src/nuxt.ts
@@ -9,7 +9,7 @@ export interface ModuleOptions extends Options {}
 export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: 'nuxt-vue-jsx-vapor',
-    configKey: 'unpluginStarter',
+    configKey: 'jsxVapor',
   },
   setup(options) {
     addVitePlugin(() => vite(options))


### PR DESCRIPTION
Change the placeholder nuxt module config key to a unique one for vue jsx vapor.