### PR TITLE
fix(macros): resolve compile error in `defineExpose`

### DIFF
--- a/packages/macros/src/core/define-expose.ts
+++ b/packages/macros/src/core/define-expose.ts
@@ -6,9 +6,16 @@ export function transformDefineExpose(
   node: CallExpression,
   s: MagicString,
 ): void {
-  s.overwrite(node.callee.start!, node.callee.end!, ';')
+  const argument = node.arguments[0]
+  const typeParameters = node.typeParameters ?? node.typeArguments
+  s.overwrite(node.callee.start!, typeParameters?.end ?? node.callee.end!, ';')
   s.appendRight(
-    node.arguments[0]?.start || node.end! - 1,
-    `${importHelperFn(s, 'getCurrentInstance', undefined, '/vue-jsx-vapor/props')}().exposed = `,
+    argument?.start ?? node.end! - 1,
+    `${importHelperFn(
+      s,
+      'getCurrentInstance',
+      undefined,
+      '/vue-jsx-vapor/props',
+    )}().exposed = ${argument ? '' : '{}'}`,
   )
 }

--- a/packages/macros/tests/__snapshots__/fixtures.spec.ts.snap
+++ b/packages/macros/tests/__snapshots__/fixtures.spec.ts.snap
@@ -149,6 +149,21 @@ export const Comp2 = ({ foo, ...__props }: any) => {
   })
   return <div />
 }
+
+export const Comp3 = () => {
+  ;(__getCurrentInstance().exposed = {})
+  return <div />
+}
+
+export const Comp4 = () => {
+  ;(__getCurrentInstance().exposed = { foo: 1 })
+  return <div />
+}
+
+export const Comp5 = () => {
+  ;(__getCurrentInstance().exposed = {})
+  return <div />
+}
 "
 `;
 

--- a/packages/macros/tests/fixtures/define-expose.tsx
+++ b/packages/macros/tests/fixtures/define-expose.tsx
@@ -18,3 +18,18 @@ export const Comp2 = ({ foo }: any) => {
   })
   return <div />
 }
+
+export const Comp3 = () => {
+  defineExpose()
+  return <div />
+}
+
+export const Comp4 = () => {
+  defineExpose<{ foo: number }>({ foo: 1 })
+  return <div />
+}
+
+export const Comp5 = () => {
+  defineExpose<{ foo?: number }>()
+  return <div />
+}


### PR DESCRIPTION
`defineExpose()` generates incorrect code snippets when called without arguments or when a generic type is provided.

Please refer to the test case for the reproduction code.