### PR TITLE
feat(compiler/vdom): add mergeProps option

### DIFF
--- a/packages/compiler-rs/crates/common/src/options.rs
+++ b/packages/compiler-rs/crates/common/src/options.rs
@@ -77,6 +77,7 @@ pub struct TransformOptions<'a> {
   pub key_index: RefCell<i32>,
   pub optimize: bool,
   pub runtime_module_name: Option<String>,
+  pub merge_props: bool,
   pub scope_identifiers_map: RefCell<HashMap<Span, (bool, Vec<&'a str>)>>,
 }
 
@@ -111,6 +112,7 @@ impl<'a> Default for TransformOptions<'a> {
       key_index: RefCell::new(0),
       optimize: true,
       runtime_module_name: None,
+      merge_props: true,
       scope_identifiers_map: RefCell::new(HashMap::new()),
     }
   }

--- a/packages/compiler-rs/crates/vdom/src/transform/transform_element.rs
+++ b/packages/compiler-rs/crates/vdom/src/transform/transform_element.rs
@@ -577,9 +577,17 @@ pub fn build_props<'a>(
       merge_args.push(ast.expression_object(node.span, dedupe_properties(properties, ast)));
     }
     if merge_args.len() > 1 {
+      let merge_props = if context.options.merge_props {
+        context.options.helper("_mergeProps")
+      } else {
+        if !matches!(merge_args[0], Expression::ObjectExpression(_)) {
+          merge_args.insert(0, ast.expression_object(SPAN, ast.vec()));
+        }
+        "Object.assign"
+      };
       Some(ast.expression_call(
         node.span,
-        ast.expression_identifier(SPAN, ast.str(context.options.helper("_mergeProps"))),
+        ast.expression_identifier(SPAN, ast.str(merge_props)),
         NONE,
         ast.vec_from_iter(merge_args.into_iter().map(|arg| arg.into())),
         false,

--- a/packages/compiler-rs/crates/vdom/src/transform/utils.rs
+++ b/packages/compiler-rs/crates/vdom/src/transform/utils.rs
@@ -79,7 +79,14 @@ pub fn inject_prop<'a>(
           props_with_injection = Some(
             ast.expression_call(
               SPAN,
-              ast.expression_identifier(SPAN, ast.str(context.options.helper("_mergeProps"))),
+              ast.expression_identifier(
+                SPAN,
+                ast.str(if context.options.merge_props {
+                  context.options.helper("_mergeProps")
+                } else {
+                  "Object.assign"
+                }),
+              ),
               NONE,
               ast.vec_from_array([
                 ast
@@ -155,7 +162,14 @@ pub fn inject_prop<'a>(
       props_with_injection = Some(
         ast.expression_call(
           SPAN,
-          ast.expression_identifier(SPAN, ast.str(context.options.helper("_mergeProps"))),
+          ast.expression_identifier(
+            SPAN,
+            ast.str(if context.options.merge_props {
+              context.options.helper("_mergeProps")
+            } else {
+              "Object.assign"
+            }),
+          ),
           NONE,
           ast.vec_from_array([
             ast

--- a/packages/compiler-rs/index.d.ts
+++ b/packages/compiler-rs/index.d.ts
@@ -41,31 +41,37 @@ export interface Hmr {
 export interface CompilerOptions {
   onError?: (arg: object) => void
   onWarn?: (arg: object) => void
-  /** * Generate source map?
+  /**
+   * Generate source map?
    * @default false
    */
   sourceMap?: boolean
-  /** * Filename for source map generation.
+  /**
+   * Filename for source map generation.
    * Also used for self-recursive reference in templates
    * @default 'index.jsx'
    */
   filename?: string
-  /** * When enabled, JSX within `defineVaporComponent` is transformed to Vapor DOM,
+  /**
+   * When enabled, JSX within `defineVaporComponent` is transformed to Vapor DOM,
    * while all other JSX is transformed to Virtual DOM.
    */
   interop?: boolean
-  /** * Enabled HMR support.
+  /**
+   * Enabled HMR support.
    * - `true`/`false`: a boolean to simply enable/disable HMR. When `true`, HMR
    *   is enabled with default configuration.
    * - `Hmr`: an object to enable HMR with custom configuration.
    * @default false
    */
   hmr?: boolean | Hmr
-  /** * Enabled SSR support.
+  /**
+   * Enabled SSR support.
    * @default false
    */
   ssr?: boolean
-  /** * Whether to enable compiler optimizations, including:
+  /**
+   * Whether to enable compiler optimizations, including:
    * - **Slots**: Detect if slots are stable for more efficient updates.
    * - **Cache**: Cache event handler to avoid recreating closures on each render.
    * - **Block**: Enable block tree optimizations.
@@ -74,10 +80,21 @@ export interface CompilerOptions {
    * @default true
    */
   optimize?: boolean
-  /** * Customize where to import runtime helpers from vue-jsx-vapor.
+  /**
+   * Customize where to import runtime helpers from vue-jsx-vapor.
    * If not specified, defaults to the virtual module path (e.g., `/vue-jsx-vapor/vapor`).
    */
   runtimeModuleName?: string
+  /**
+   * Whether to merge props when using JSXSpreadAttribute.
+   * - `true`: Use Vue's `mergeProps` behavior
+   *   - Event listeners (`onXxx`) are merged into an array
+   *   - `class` and `style` are normalized and merged
+   *   - Other props are overridden by later values
+   * - `false`: later props override earlier ones (like object spread)
+   * @default true
+   */
+  mergeProps?: boolean
 }
 
 export declare function transform(source: string, options?: CompilerOptions | undefined | null): TransformReturn

--- a/packages/compiler-rs/src/lib.rs
+++ b/packages/compiler-rs/src/lib.rs
@@ -25,50 +25,44 @@ mod transform;
 pub struct CompilerOptions {
   pub on_error: Option<Function<'static, Object<'static>, ()>>,
   pub on_warn: Option<Function<'static, Object<'static>, ()>>,
-  /**
-   * Generate source map?
-   * @default false
-   */
+  /// Generate source map?
+  /// @default false
   pub source_map: Option<bool>,
-  /**
-   * Filename for source map generation.
-   * Also used for self-recursive reference in templates
-   * @default 'index.jsx'
-   */
+  /// Filename for source map generation.
+  /// Also used for self-recursive reference in templates
+  /// @default 'index.jsx'
   pub filename: Option<String>,
-  /**
-   * When enabled, JSX within `defineVaporComponent` is transformed to Vapor DOM,
-   * while all other JSX is transformed to Virtual DOM.
-   */
+  /// When enabled, JSX within `defineVaporComponent` is transformed to Vapor DOM,
+  /// while all other JSX is transformed to Virtual DOM.
   pub interop: Option<bool>,
-  /**
-   * Enabled HMR support.
-   * - `true`/`false`: a boolean to simply enable/disable HMR. When `true`, HMR
-   *   is enabled with default configuration.
-   * - `Hmr`: an object to enable HMR with custom configuration.
-   * @default false
-   */
+  /// Enabled HMR support.
+  /// - `true`/`false`: a boolean to simply enable/disable HMR. When `true`, HMR
+  ///   is enabled with default configuration.
+  /// - `Hmr`: an object to enable HMR with custom configuration.
+  /// @default false
   pub hmr: Option<Either<bool, Hmr>>,
-  /**
-   * Enabled SSR support.
-   * @default false
-   */
+  /// Enabled SSR support.
+  /// @default false
   pub ssr: Option<bool>,
-  /**
-   * Whether to enable compiler optimizations, including:
-   * - **Slots**: Detect if slots are stable for more efficient updates.
-   * - **Cache**: Cache event handler to avoid recreating closures on each render.
-   * - **Block**: Enable block tree optimizations.
-   *
-   * Note: this option is only used in interop mode.
-   * @default true
-   */
+  /// Whether to enable compiler optimizations, including:
+  /// - **Slots**: Detect if slots are stable for more efficient updates.
+  /// - **Cache**: Cache event handler to avoid recreating closures on each render.
+  /// - **Block**: Enable block tree optimizations.
+  ///
+  /// Note: this option is only used in interop mode.
+  /// @default true
   pub optimize: Option<bool>,
-  /**
-   * Customize where to import runtime helpers from vue-jsx-vapor.
-   * If not specified, defaults to the virtual module path (e.g., `/vue-jsx-vapor/vapor`).
-   */
+  /// Customize where to import runtime helpers from vue-jsx-vapor.
+  /// If not specified, defaults to the virtual module path (e.g., `/vue-jsx-vapor/vapor`).
   pub runtime_module_name: Option<String>,
+  /// Whether to merge props when using JSXSpreadAttribute.
+  /// - `true`: Use Vue's `mergeProps` behavior
+  ///   - Event listeners (`onXxx`) are merged into an array
+  ///   - `class` and `style` are normalized and merged
+  ///   - Other props are overridden by later values
+  /// - `false`: later props override earlier ones (like object spread)
+  /// @default true
+  pub merge_props: Option<bool>,
 }
 
 #[cfg(feature = "napi")]
@@ -94,6 +88,7 @@ pub fn _transform(env: Env, source: String, options: Option<CompilerOptions>) ->
       ssr,
       optimize: options.optimize.unwrap_or(true),
       runtime_module_name: options.runtime_module_name,
+      merge_props: options.merge_props.unwrap_or(true),
       on_error: if let Some(on_error) = options.on_error {
         Box::new(move |code: ErrorCodes, span: Span| {
           let compiler_error = create_compiler_error(&env, code, span).unwrap();

--- a/packages/compiler-rs/tests/transform/options.rs
+++ b/packages/compiler-rs/tests/transform/options.rs
@@ -64,3 +64,56 @@ pub fn optimize_slots() {
   _createVNode(Comp, null, _normalizeSlots(foo));
   "#);
 }
+
+#[test]
+pub fn merge_props() {
+  let code = transform(
+    "<Comp {...foo} onClick={() => {}} />",
+    Some(TransformOptions {
+      interop: true,
+      optimize: false,
+      merge_props: false,
+      ..Default::default()
+    }),
+  )
+  .code;
+  assert_snapshot!(code, @r#"
+  import { createVNode as _createVNode } from "vue";
+  _createVNode(Comp, Object.assign({}, foo, { onClick: () => {} }));
+  "#);
+}
+
+#[test]
+pub fn merge_props_object() {
+  let code = transform(
+    "<Comp {...{ onClick: () => {} }} onClick={() => {}} />",
+    Some(TransformOptions {
+      interop: true,
+      optimize: false,
+      merge_props: false,
+      ..Default::default()
+    }),
+  )
+  .code;
+  assert_snapshot!(code, @r#"
+  import { createVNode as _createVNode } from "vue";
+  _createVNode(Comp, Object.assign({ onClick: () => {} }, { onClick: () => {} }));
+  "#);
+}
+
+#[test]
+fn merge_props_with_v_if() {
+  let code = transform(
+    r#"<button {...foo} v-if={true}></button>"#,
+    Some(TransformOptions {
+      interop: true,
+      merge_props: false,
+      ..Default::default()
+    }),
+  )
+  .code;
+  assert_snapshot!(code, @r#"
+  import { createCommentVNode as _createCommentVNode, createElementBlock as _createElementBlock, guardReactiveProps as _guardReactiveProps, normalizeProps as _normalizeProps, openBlock as _openBlock } from "vue";
+  true ? (_openBlock(), _createElementBlock("button", Object.assign({ key: 0 }, foo), null, 16)) : _createCommentVNode("", true);
+  "#)
+}


### PR DESCRIPTION
Fix: https://github.com/tusen-ai/naive-ui/issues/8186

By default, `vue-jsx-compiler` uses the `mergeProps` helper from `vue` to merge event listeners, `class`, and `style` when encountering `JSXSpreadAttribute`.

This PR introduces a `mergeProps` option. When set to `false`, it will use `Object.assign` (override behavior) instead of `mergeProps` to handle `JSXSpreadAttribute`.

```ts
// vite.config.ts
import vueJsxCompiler from 'vue-jsx-vapor/vite'
vueJsxCompiler({
  interop: true,
  compiler: {
    mergeProps: false
  }
})
```